### PR TITLE
Bugfix LUT principal point, supersampling and border pixel

### DIFF
--- a/src/anycam/model/cls_camera_lut.py
+++ b/src/anycam/model/cls_camera_lut.py
@@ -673,20 +673,53 @@ class CCameraLut:
 
                 # print(f"aDelta, aX, fXlen: {aDelta}, {aX}, {fXlen}")
                 # print(f"aDelta, aY, fYlen: {aDelta}, {aY}, {fYlen}")
-
-                fDeltaPixX = np.dot(aDelta, aX) / (fXlen * fXlen)
-                fDeltaPixY = np.dot(aDelta, aY) / (fYlen * fYlen)
+                if fXlen == 0:
+                    fDeltaPixX = 0
+                else:
+                    fDeltaPixX = np.dot(aDelta, aX) / (fXlen * fXlen)
+                if fYlen == 0:
+                    fDeltaPixY = 0
+                else:
+                    fDeltaPixY = np.dot(aDelta, aY) / (fYlen * fYlen)
                 # #####################################################
 
                 lPosRC = [float(iRowIdx + fDeltaPixY), float(iColIdx + fDeltaPixX)]
                 lPosRC = list(self.LutToImgPixel(lPosRC))
 
                 bValid: bool = (
-                    lPosRC[0] >= -0.5
-                    and lPosRC[0] <= iRowCnt + 0.5
-                    and lPosRC[1] >= -0.5
-                    and lPosRC[1] <= iColCnt + 0.5
+                    lPosRC[0] * self._iLutSuperSampling + self._iLutBorderPixel
+                    >= -0.5 * (1 / self._iLutSuperSampling)
+                    and lPosRC[0] * self._iLutSuperSampling + self._iLutBorderPixel
+                    <= iRowCnt
+                    and lPosRC[1] * self._iLutSuperSampling + self._iLutBorderPixel
+                    >= -0.5 * (1 / self._iLutSuperSampling)
+                    and lPosRC[1] * self._iLutSuperSampling + self._iLutBorderPixel
+                    <= iColCnt
                 )
+
+                if bValid:
+                    lPosRCRay = self._imgLut[
+                        max(
+                            0,
+                            int(
+                                np.floor(
+                                    lPosRC[0] * self._iLutSuperSampling
+                                    + self._iLutBorderPixel
+                                )
+                            ),
+                        ),
+                        max(
+                            0,
+                            int(
+                                np.floor(
+                                    lPosRC[1] * self._iLutSuperSampling
+                                    + self._iLutBorderPixel
+                                )
+                            ),
+                        ),
+                    ]
+                    if lPosRCRay[0] == 0 and lPosRCRay[1] == 0 and lPosRCRay[2] == 0:
+                        bValid = False
 
                 break
             # endwhile dummy

--- a/src/anycam/obj/cls_cameraview_lut.py
+++ b/src/anycam/obj/cls_cameraview_lut.py
@@ -153,6 +153,16 @@ class CCameraViewLut(CCameraView):
         # Flip row-column to x-y order
         aPixPosXY = aPixPosRC[:, ::-1]
 
+        # Filter out pixels outside the imager
+        lPixelValid = [
+            v
+            & (p[0] < self._lPixCnt[0])
+            & (p[1] < self._lPixCnt[1])
+            & (p[0] > 0)
+            & (p[1] > 0)
+            for p, v in zip(aPixPosXY, lPixelValid)
+        ]
+
         if _bDetailedFlags is True:
             return aPixPosXY.tolist(), lPixelValid, lPixelValid
         else:


### PR DESCRIPTION
Bugfix regarding the lookup table:

- convention mismatch between Blender and OpenCV which resulted in an incorrect usage of the principal point in the vertical direction
- filtering of projected points with invalid distortion, based on the LUT
- passing of supersampling and border pixel parameters to the script generating the LUT