### PR TITLE
Feature/transform all view layers

### DIFF
--- a/src/anycam/ops.py
+++ b/src/anycam/ops.py
@@ -1633,7 +1633,7 @@ def _SetWorldShaderRotation(*, xContext, tAngles):
 
 
 #######################################################################################
-def TransformSceneToCameraFrame(*, xContext):
+def TransformSceneToCameraFrame(*, xContext: bpy.context):
     global c_sOriginName
     # Try to revert any previous transformation before applying a new one
     RevertTransformSceneToCameraFrame(xContext=xContext, bDoThrow=False)
@@ -1645,7 +1645,7 @@ def TransformSceneToCameraFrame(*, xContext):
 
     matCamInv = matCam.inverted()
 
-    _TransformObjectsWorldMatrix(xObjects=xContext.view_layer.objects, matX=matCamInv)
+    _TransformObjectsWorldMatrix(xObjects=xContext.scene.objects, matX=matCamInv)
 
     eulX = objCam.matrix_world.to_euler()
     tAngles = (eulX.x, eulX.y, eulX.z)
@@ -1657,7 +1657,10 @@ def TransformSceneToCameraFrame(*, xContext):
     xContext.scene.frame_set(iFrameCur + 1)
     xContext.scene.frame_set(iFrameCur)
 
-    xContext.view_layer.update()
+    layer: bpy.types.ViewLayer
+    for layer in xContext.scene.view_layers:
+        layer.update()
+    # endfor
 
     return True
 

--- a/src/anycam/ops.py
+++ b/src/anycam/ops.py
@@ -1693,7 +1693,7 @@ def GetTransformCameraFrame() -> list:
 
 
 #######################################################################################
-def RevertTransformSceneToCameraFrame(*, xContext, bDoThrow=True):
+def RevertTransformSceneToCameraFrame(*, xContext: bpy.context, bDoThrow: bool=True):
     global c_sOriginName
     # assume that there is at most one camera object with
     # the original world coordinate system as a property.
@@ -1721,7 +1721,7 @@ def RevertTransformSceneToCameraFrame(*, xContext, bDoThrow=True):
     # matOrig = mathutils.Matrix(lMatOrig)
     # _TransformObjectsWorldMatrix(xObjects=xContext.view_layer.objects, matX=matOrig)
 
-    _RestoreObjectsWorldMatrix(xObjects=xContext.view_layer.objects)
+    _RestoreObjectsWorldMatrix(xObjects=xContext.scene.objects)
     _SetWorldShaderRotation(xContext=xContext, tAngles=(0, 0, 0))
 
     del objCam[c_sOriginName]
@@ -1732,7 +1732,10 @@ def RevertTransformSceneToCameraFrame(*, xContext, bDoThrow=True):
     xContext.scene.frame_set(iFrameCur + 1)
     xContext.scene.frame_set(iFrameCur)
 
-    xContext.view_layer.update()
+    layer: bpy.types.ViewLayer
+    for layer in xContext.scene.view_layers:
+        layer.update()
+    # endfor
 
     return True
 


### PR DESCRIPTION
When using the feature "Transform Scene to Camera Frame" for non-Blender native cameras, now all objects on all view layers of the scene are transformed.